### PR TITLE
fix: directly change the plugin parallel value instead of wrapping it

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -41,7 +41,6 @@ function ${WRAPPER_KEY} (plugin) {
               return !(!importItem || importItem.path.includes('nuxt/dist')) 
             })
               .map((i) => {
-                console.log(i)
                 return `${WRAPPER_KEY}(${i})`
               })
             return `\n${content.includes(WRAPPER_KEY) ? '' : snippets}\n${items.join('\n')}\n${full}\n`


### PR DESCRIPTION
This PR is to avoid nuxt devttols not wrapping plugins with `__DEVTOOLS_WRAPPER__` because it uses a regex on the export default array.